### PR TITLE
Updated rack 2.2.3 -> 2.2.13

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
       forwardable-extended (~> 2.6)
     public_suffix (4.0.7)
     racc (1.6.0)
-    rack (2.2.3)
+    rack (2.2.13)
     rainbow (3.1.1)
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)


### PR DESCRIPTION
Updated rack to latest version 2.2.13. Build completed with no errors. [Preview Link](https://federalist-3517e678-c450-4c82-a168-73c2caca984c.sites.pages.cloud.gov/preview/gsa/assets.cio.gov/RITM1317778/)