### PR TITLE
Ritm1336237

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.5)
+    rexml (3.2.7)
     rouge (3.28.0)
     safe_yaml (1.0.5)
     sassc (2.4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,10 +85,6 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (2.4.0)
-      rexml
-    kramdown-parser-gfm (1.1.0)
-      kramdown (~> 2.0)
     liquid (4.0.3)
     liquid-tag-parser (2.0.2)
       extras (~> 0.3)
@@ -112,7 +108,6 @@ GEM
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.6)
     rouge (3.28.0)
     safe_yaml (1.0.5)
     sassc (2.4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.7)
+    rexml (3.2.6)
     rouge (3.28.0)
     safe_yaml (1.0.5)
     sassc (2.4.0)


### PR DESCRIPTION
Remove rexml and kramdown from gemfile
Related to https://github.com/GSA/assets.cio.gov/pull/41
RITM1336237

Preview Link: https://federalist-3517e678-c450-4c82-a168-73c2caca984c.sites.pages.cloud.gov/preview/gsa/assets.cio.gov/RITM1336237/

Asset example: https://federalist-3517e678-c450-4c82-a168-73c2caca984c.sites.pages.cloud.gov/preview/gsa/assets.cio.gov/RITM1336237/assets/files/resources/CIOC-Federal-Shared-Services-Implementation-Guide.pdf