### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,7 +1,9 @@
 name: Build and test Jekyll USWDS
 
-on: [push]
+permissions:
+  contents: read
 
+on: [push]
 jobs:
   build:
     name: Install, build and test site with pa11y-ci and htmlproofer.


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/assets.cio.gov/security/code-scanning/1](https://github.com/GSA/assets.cio.gov/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only needs to read the repository contents (e.g., to check out the source code), we will set `contents: read`. This ensures the workflow has the least privileges required to complete its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
